### PR TITLE
feat(wasmBinary):  Allow pre-fetching of wasmBinary

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ _ext_ optional "extra params":
 }
 ```
 * _wasmFolder_: An optional `string` specifying the location of wasm file.
+* _wasmBinary_: An optional "pre-fetched" copy of the wasm binary as returned from `XHR` or `fetch`.
 * _yInvert_: An optional boolean flag to invert the y coordinate in generic output formats (dot, xdot, plain, plain-ext).  This is equivalent to specifying -y when invoking Graphviz from the command-line. 
 * _nop_: An optional number to specify "No layout" mode for the neato engine.  This is equivalent to specifying the -n option when invoking Graphviz from the command-line.
 
@@ -218,9 +219,9 @@ Convenience function that performs **patchwork** layout, is equivalent to `layou
 
 Convenience function that performs **twopi** layout, is equivalent to `layout(dotSource, outputFormat, "twopi");`.
 
-<a name="graphvizSync" href="#graphvizSync">#</a> **graphvizSync**([_wasmFolder_]) · [<>](https://github.com/hpcc-systems/hpcc-js-wasm/blob/trunk/src/graphviz.ts "Source")
+<a name="graphvizSync" href="#graphvizSync">#</a> **graphvizSync**([_wasmFolder_], [_wasmBinary_]) · [<>](https://github.com/hpcc-systems/hpcc-js-wasm/blob/trunk/src/graphviz.ts "Source")
 
-Returns a `Promise<GraphvizSync>`, once resolved provides a synchronous variant of the above methods.  Has an optional `wasmFolder` argument to override the default wasmFolder location.
+Returns a `Promise<GraphvizSync>`, once resolved provides a synchronous variant of the above methods.  Has an optional `wasmFolder` argument to override the default wasmFolder location and optional `wasmBinary` to short circuit the wasm downloading process.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -6,12 +6,15 @@
     <title>GraphViz WASM</title>
 
     <script>
+        var wasmBinaryFile;
         switch (window.location.hostname) {
             case "localhost":
                 document.write('<script type="text/javascript" src="./dist/index.js"><' + '/script>');
+                wasmBinaryFile = "./dist/graphvizlib.wasm";
                 break;
             default:
                 document.write('<script src="https://cdn.jsdelivr.net/npm/@hpcc-js/wasm/dist/index.min.js"><' + '/script>');
+                wasmBinaryFile = "https://cdn.jsdelivr.net/npm/@hpcc-js/wasm/dist/graphvizlib.wasm";
                 break;
         }
     </script>
@@ -22,14 +25,16 @@
 </head>
 
 <body>
-    <h3>One</h3>
+    <h3>Async DOT</h3>
     <div id="placeholder"></div>
     <br>
     <h3>Two</h3>
     <div id="placeholder2"></div>
     <br>
-    <h3>Three</h3>
+    <h3>Sync DOT</h3>
     <div id="placeholder3"></div>
+    <h3>Cached wasmBinary</h3>
+    <div id="placeholder4"></div>
     <h3>End</h3>
     <script>
         const dot = `
@@ -96,6 +101,18 @@
             } catch (e) {
                 div.innerHTML = e.message;
             }
+        });
+
+        fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(response => {
+            if (!response.ok) {
+                throw "failed to load wasm binary file at '" + wasmBinaryFile + "'";
+            }
+            return response.arrayBuffer();
+        }).then(wasmBinary => {
+            hpccWasm.graphviz.layout(dot, "svg", "dot", { wasmBinary: wasmBinary }).then(svg => {
+                const div = document.getElementById("placeholder4");
+                div.innerHTML = svg;
+            }).catch(err => console.error(err.message));
         });
     </script>
 

--- a/src/expat.ts
+++ b/src/expat.ts
@@ -62,8 +62,8 @@ function parseAttrs(attrs: string): Attributes {
     return retVal;
 }
 
-export function parse(xml: string, callback: IParser, wasmFolder?: string): Promise<boolean> {
-    return loadWasm(expatlib, wasmFolder).then(module => {
+export function parse(xml: string, callback: IParser, wasmFolder?: string, wasmBinary?: Uint8Array): Promise<boolean> {
+    return loadWasm(expatlib, wasmFolder, wasmBinary).then(module => {
         const parser = new module.CExpatJS();
         parser.startElement = function () {
             callback.startElement(this.tag(), parseAttrs(this.attrs()));

--- a/src/graphviz.ts
+++ b/src/graphviz.ts
@@ -20,6 +20,7 @@ interface Ext {
     images?: Image[];
     files?: File[];
     wasmFolder?: string;
+    wasmBinary?: Uint8Array;
     yInvert?: boolean;
     nop?: number;
 }
@@ -49,7 +50,7 @@ function createFiles(wasm: any, _ext?: Ext) {
 export const graphviz = {
     layout(dotSource: string, outputFormat: Format = "svg", layoutEngine: Engine = "dot", ext?: Ext): Promise<string> {
         if (!dotSource) return Promise.resolve("");
-        return loadWasm(graphvizlib, ext?.wasmFolder).then(wasm => {
+        return loadWasm(graphvizlib, ext?.wasmFolder, ext?.wasmBinary).then(wasm => {
             createFiles(wasm, ext);
             wasm.Main.prototype.setYInvert(ext?.yInvert ? 1 : 0);
             wasm.Main.prototype.setNop(ext?.nop ? ext?.nop : 0);
@@ -136,6 +137,6 @@ export class GraphvizSync {
     }
 }
 
-export function graphvizSync(wasmFolder?: string): Promise<GraphvizSync> {
-    return loadWasm(graphvizlib, wasmFolder).then(wasm => new GraphvizSync(wasm));
+export function graphvizSync(wasmFolder?: string, wasmBinary?: Uint8Array): Promise<GraphvizSync> {
+    return loadWasm(graphvizlib, wasmFolder, wasmBinary).then(wasm => new GraphvizSync(wasm));
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,12 +22,13 @@ function trimStart(str: string, charToRemove: string) {
     return str;
 }
 
-export function loadWasm(_wasmLib: any, wf?: string): Promise<any> {
+export function loadWasm(_wasmLib: any, wf?: string, wasmBinary?: Uint8Array): Promise<any> {
     const wasmLib = _wasmLib.default || _wasmLib;
     //  Prevent double load ---
     if (!wasmLib.__hpcc_promise) {
         wasmLib.__hpcc_promise = new Promise(resolve => {
             wasmLib({
+                wasmBinary,
                 locateFile: (path: string, prefix: string) => {
                     return `${trimEnd(wf || wasmFolder() || prefix || ".", "/")}/${trimStart(path, "/")}`;
                 }


### PR DESCRIPTION
Allow user to provide a pre-fetched copy of the wasm binary as returned from XHR or a fetch.

Fixes #53

Signed-off-by: Gordon Smith <GordonJSmith@gmail.com>