### PR TITLE
chore:  Bump Graphviz version to v2.49.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Test PR](https://github.com/hpcc-systems/hpcc-js-wasm/workflows/Test%20PR/badge.svg)
 
 This repository contains a collection of useful c++ libraries compiled to WASM for (re)use in Node JS, Web Browsers and JavaScript Libraries:
-* [graphviz](https://www.graphviz.org/) - v2.49.2
+* [graphviz](https://www.graphviz.org/) - v2.49.3
 * [expat](https://libexpat.github.io/) - v2.4.1
 
 Built with:

--- a/scripts/cpp-install-graphviz.sh
+++ b/scripts/cpp-install-graphviz.sh
@@ -3,10 +3,10 @@
 if [ ! -d "src-graphviz" ] 
 then
     #  https://gitlab.com/graphviz/graphviz/-/tags
-    wget -c https://gitlab.com/graphviz/graphviz/-/archive/2.49.2/graphviz-2.49.2.tar.gz
+    wget -c https://gitlab.com/graphviz/graphviz/-/archive/2.49.3/graphviz-2.49.3.tar.gz
     mkdir ./src-graphviz
-    tar -xzf ./graphviz-2.49.2.tar.gz -C ./src-graphviz --strip-components=1
-    rm ./graphviz-2.49.2.tar.gz
+    tar -xzf ./graphviz-2.49.3.tar.gz -C ./src-graphviz --strip-components=1
+    rm ./graphviz-2.49.3.tar.gz
 
     #  Generate grammar files (and others)  ---
     cd ./src-graphviz


### PR DESCRIPTION
Signed-off-by: Gordon Smith <GordonJSmith@gmail.com>