### PR TITLE
fix: Add missing DuckDB to wasm package

### DIFF
--- a/packages/wasm/esbuild.mjs
+++ b/packages/wasm/esbuild.mjs
@@ -3,6 +3,7 @@ import { bothTpl, browserBoth, nodeBoth } from "@hpcc-js/esbuild-plugins";
 //  config  ---
 await Promise.all([
     bothTpl("src/base91.ts", "dist/base91", undefined, "@hpcc-js/wasm"),
+    bothTpl("src/duckdb.ts", "dist/duckdb", undefined, "@hpcc-js/wasm"),
     bothTpl("src/graphviz.ts", "dist/graphviz", undefined, "@hpcc-js/wasm"),
     bothTpl("src/expat.ts", "dist/expat", undefined, "@hpcc-js/wasm"),
     bothTpl("src/zstd.ts", "dist/zstd", undefined, "@hpcc-js/wasm")


### PR DESCRIPTION
Fixes #257