### PR TITLE
Add support for the `canon` output format

### DIFF
--- a/packages/graphviz/src/graphviz.ts
+++ b/packages/graphviz/src/graphviz.ts
@@ -4,7 +4,7 @@ import load, { reset } from "../../../build/packages/graphviz/src-cpp/graphvizli
 /**
  * Various graphic and data formats for end user, web, documents and other applications.  See [Output Formats](https://graphviz.gitlab.io/docs/outputs/) for more information.
  */
-export type Format = "svg" | "dot" | "json" | "dot_json" | "xdot_json" | "plain" | "plain-ext";
+export type Format = "svg" | "dot" | "json" | "dot_json" | "xdot_json" | "plain" | "plain-ext" | "canon";
 
 /**
  * Various algorithms for projecting abstract graphs into a space for visualization.  See [Layout Engines](https://graphviz.gitlab.io/docs/layouts/) for more details.

--- a/packages/graphviz/test/graphviz.ts
+++ b/packages/graphviz/test/graphviz.ts
@@ -4,7 +4,7 @@ import { badDot, dot } from "./dot001.js";
 import { ortho } from "./dot002.js";
 import { dotMemory } from "./dot003.js";
 
-export const formats: Format[] = ["svg", "dot", "json", "dot_json", "xdot_json", "plain", "plain-ext"];
+export const formats: Format[] = ["svg", "dot", "json", "dot_json", "xdot_json", "plain", "plain-ext", "canon"];
 export const engines: Engine[] = ["circo", "dot", "fdp", "sfdp", "neato", "osage", "patchwork", "twopi", "nop", "nop2"];
 
 describe("all combos", function () {


### PR DESCRIPTION
Support the [`canon`](https://graphviz.gitlab.io/docs/outputs/canon/) format, to allow formatting DOT files without performing any layout.

This works today, but the type-checker is not happy about it. So I want to add it to the `Format` options.