### PR TITLE
Fix graphviz CLI package entrypoints

### DIFF
--- a/packages/graphviz-cli/package.json
+++ b/packages/graphviz-cli/package.json
@@ -9,12 +9,13 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "default": "./dist/index.js"
+      "default": "./bin/index.js"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./bin/index.js",
   "types": "./types/index.d.ts",
   "files": [
+    "bin/**/*",
     "dist/**/*",
     "src/**/*",
     "types/**/*"


### PR DESCRIPTION
## Summary

- point `@hpcc-js/wasm-graphviz-cli` `main` and default export at the generated CLI bundle in `bin/index.js`
- include `bin/**/*` in the package `files` list so the declared entrypoint is explicit

## Verification

- `npm pack @hpcc-js/wasm-graphviz-cli@1.9.2 --json`
- confirmed the published tarball contains `package/bin/index.js` and `package/types/index.d.ts`
- confirmed the published tarball does not contain `package/dist/index.js`, even though current `main`/exports point there
- node assertion that package metadata now points `main` and default export to `./bin/index.js`
- `git diff --check`